### PR TITLE
Update error message

### DIFF
--- a/src/SeedForm.tsx
+++ b/src/SeedForm.tsx
@@ -55,7 +55,7 @@ const SeedForm: React.FC = () => {
       setFormData({ ...formData, mnemonic: mnemonic || "" });
     } catch(e) {
       console.error(e)
-      setFormData({ ...formData, mnemonic: `failed to decrypt: ${e}`});
+      setFormData({ ...formData, mnemonic: `failed to decrypt. email, password, and/or encrypted wallet are incorrect.`});
     }
   };
 


### PR DESCRIPTION
If a user inputs an invalid email, password, or encrypted mnemonic, the error message displayed is "failed to decrypt: Error: HMAC signature is not valid or data has been tampered with."

this could confuse users who most likely have just input a wrong email or password, so this PR replaces the dynamic error message with "failed to decrypt. email, password, and/or encrypted wallet are incorrect."

<img width="442" alt="image" src="https://github.com/willyogo/mnemonic-recovery-ui/assets/26232238/1e504784-10d0-47f3-bc5a-45653ba6fe91">

note:
while the original code returns a dynamic error message, this PR makes the error message static. i wasn't sure how to find/modify the code for dynamic error messages, but also wasn't able to trigger any other error messages when testing incorrect email, password, and encrypted string, so was thinking the dynamic code may not be necessary. separate error handling is already in place if a user doesn't enter email, pw, or encryptedWallet and is not affected by this change.

